### PR TITLE
Clarifies standard api types for span

### DIFF
--- a/apis.md
+++ b/apis.md
@@ -9,3 +9,10 @@ The following OpenTracing APIs are currently available in the RFC stage:
 
 Please refer to the README files in the respective projects for examples of usage.
 
+### Implementation Notes
+
+OpenTracing APIs intend to express a similar experience to the user, while still being idiomatic to the language or framework. The following concepts apply to all variants.
+
+A **Span** is shared mutable state. It accumulates tags and logs, and can also create children. Finishing a span means capturing its state as a SpanRecord.
+
+A **SpanRecord** is an immutable representation of a completed span. It can be reported directly to an OpenTracing system, or encoded into a representation of an alternate system, such as HTrace or Zipkin.


### PR DESCRIPTION
Prior to this change, there was a mutable accumulator called `Span` (similar to HTrace's one), and also a concept of a immutable finished span called `RawSpan`. Since `RawSpan` was the input of `RecordSpan`, and "raw" distracts at least me, this changes terminology to say `SpanRecord`. I believe `SpanRecord` more closely relates both the the apis that use it, and also it being the canonical immutable struct.