### PR TITLE
remove TraceContext from the docs, too

### DIFF
--- a/spec.md
+++ b/spec.md
@@ -124,7 +124,7 @@ Note that there is no expectation that different tracing systems propagate `Span
 The `SpanPropagator` interface must have the following capabilities:
 - Propagating a Span instance by encoding it as either...
   - a pair of binary values **(py: `propagate_span_as_binary`, go: `PropagateSpanAsBinary`)**, or
-  - a pair of text-encoded `string->string` maps, where the keys are suitable for use in HTTP headers (see the notes about "trace attribute" keys above) **(py: `propagate_span_as_text`, go: `PropagateSpanAsText`)**
+  - a pair of unicode `string->string` maps, where the keys are suitable for use in HTTP headers (see the notes about "trace attribute" keys above) **(py: `propagate_span_as_text`, go: `PropagateSpanAsText`)**
 - Returning a new Span instance that joins to a Span previously propagated via either...
   - a pair of binary values **(py: `join_trace_from_binary`, go: `JoinTraceFromBinary`)**, or
-  - a pair of `string->string` maps **(py: `join_trace_from_text`, go: `JoinTraceFromText`)**
+  - a pair of unicode `string->string` maps **(py: `join_trace_from_text`, go: `JoinTraceFromText`)**

--- a/spec.md
+++ b/spec.md
@@ -49,9 +49,9 @@ Every Span has zero or more **Logs**, each of which being a timestamped event na
 
 Every Span may also have zero or more key/value **Tags**, which do not have timestamps and simply annotate the spans.
 
-Every Span is bound to a **Trace Context**. The Trace Context describes how the Span it's bound to fits in to the larger Trace. A Trace Context encapsulates the smallest amount of state needed to continue a Trace across a process boundary (or, more generally, a serialization boundary). Put another way, a Span cannot exist without a Trace Context, but a Trace Context can be (and is) serialized without a Span: Spans are built around their Trace Context and concern themselves with application-level instrumentation (logs, timing information, tags). Note that, in order to support *Trace Attributes* (see below) that propagate across a distributed Trace transparently, those attributes must be represented by/within the Trace Context.
+Spans may be **propagated**; that is, they may cross process boundaries along with sufficient information to continue the Trace on the far side of the propagation.
 
-**Trace Attributes** are key/value pairs stored in a Trace Context and propagated _in-band_ to all future child Spans. Given a full-stack OpenTracing integration, Trace Attributes enable powerful functionality by transparently propagating arbitrary application data: for example, an end-user id may be added as a Trace Attribute in a mobile app, propagate (via the distributed tracing machinery) into the depths of a storage system, and recovered at the bottom of the stack to identify a particularly expensive SQL query.
+**Trace Attributes** are key/value pairs stored in a Span and propagated _in-band_ to all future child Spans. Given a full-stack OpenTracing integration, Trace Attributes enable powerful functionality by transparently propagating arbitrary application data: for example, an end-user id may be added as a Trace Attribute in a mobile app, propagate (via the distributed tracing machinery) into the depths of a storage system, and recovered at the bottom of the stack to identify a particularly expensive SQL query.
 
 Trace Attributes come with powerful _costs_ as well; since the attributes are propagated in-band, if they are too large or too numerous they may reduce system throughput or contribute to RPC latency.
 
@@ -60,39 +60,22 @@ Trace Attributes come with powerful _costs_ as well; since the attributes are pr
 * Trace Attributes are propagated in-band (i.e., alongside the actual application data) across process boundaries. Span Tags are not propagated since they are not inherited from parent Span to child Span.
 * Span Tags are recorded out-of-band from the application data, presumably in the tracing system's storage. Trace Attributes are not necessarily recorded here, though an implementation may elect to.
 
+Also, trace attribute keys have a restricted format: implementations may wish to use them as HTTP header keys (or key suffixes), and of course HTTP headers are case insensitive. As such, trace attribute keys MUST match the regular expression `(?i:[a-z0-9][-a-z0-9]*)`, and – per the `?i:` – they are case-insensitive. That is, the trace attribute key must start with a letter or number, and the remaining characters must be letters, numbers, or hyphens.
+
+
 ## Platform-Independent API Semantics
 
 OpenTracing supports a number of different platforms, and of course the per-platform APIs try to blend in to their surroundings and do as the Romans do. That said, each platform API must model a common set of semantics for the core tracing concepts described above. In this document we attempt to describe those concepts and semantics in a language- and platform-agnostic fashion.
-
-### Tracer
-
-The `Tracer` interface must have the following capabilities:
-
-- Start a `Span` that has no parent, commonly referred to as a *root* `Span` **(py: `start_trace`, go: `StartTrace`)**
-- Start a `Span` as a descendant of a parent `TraceContext` **(py: `join_trace`, go: `JoinTrace`)**
-- Start a `Span` explicitly built around a specific `TraceContext` **(py: `Span(trace_context)`, go: `StartSpanWithContext`)**
-
 
 ### Span
 
 The `Span` interface must have the following capabilities:
 
-- Create and start a new child `Span` with a given operation name. The child `Span`'s `TraceContext` must descend from the parent `Span`'s `TraceContext`, and any trace attributes must propagate through into the child's `TraceContext`. **(py: `start_child`, go: `StartChild`)**
+- Create and start a new child `Span` with a given operation name. Any trace attributes must be passed through into the child. **(py: `start_child`, go: `StartChild`)**
 - Finish the (already-started) `Span`.  Finish should be the last call made to any span instance, and to do otherwise leads to undefined behavior. **(py: `finish`, go: `Finish`)**
 - Set a key:value tag on the `Span`. The key must be a `string`, and the value must be either a `string`, a `boolean`, or a numeric type. Behavior for other value types is undefined. If multiple values are set to the same key (i.e., in multiple calls), implementation behavior is also undefined. **(py: `set_tag`, go: `SetTag`)**
 - Add a new log event to the `Span`, accepting an event name `string` and an optional structured payload argument. If specified, the payload argument may be of any type and arbitrary size, though implementations are not required to retain all payload arguments (or even all parts of all payload arguments). **(py: `log_event, log_event_with_payload`, go: `LogEvent, LogEventWithPayload`)**
-- Access the `TraceContext` associated with the `Span`. **(py: `trace_context`, go: `TraceContext()`)**
-
-
-### TraceContext
-
-Every `TraceContext` must provide access to the "trace attributes". A **trace attribute** is a key:value pair associated with a TraceContext **that also propagates to future TraceContext children**, and that propagates across process boundaries in-band with the application data. (See the discussion of trace attributes in the "Concepts and Terminology" section above)
-
-Also, trace attribute keys have a restricted format: implementations may wish to use them as HTTP header keys (or key suffixes), and of course HTTP headers are case insensitive. As such, trace attribute keys MUST match the regular expression `(?i:[a-z0-9][-a-z0-9]*)`, and – per the `?i:` – they are case-insensitive. That is, the trace attribute key must start with a letter or number, and the remaining characters must be letters, numbers, or hyphens.
-
-In any case, the programmatic `TraceContext` interface is deceptively simple:
-
-- Set a trace attribute, which is a simple string:string pair. Note that newly-set trace attributes are only guaranteed to propagate to *future* children of the `Span` built around the given `TraceContext`. See the diagram below. **(py: `set_trace_attribute`, go: `SetTraceAttribute`)**
+- Set a trace attribute, which is a simple string:string pair. Note that newly-set trace attributes are only guaranteed to propagate to *future* children of the given `Span`. See the diagram below. **(py: `set_trace_attribute`, go: `SetTraceAttribute`)**
 - Get a trace attribute by key. **(py: `get_trace_attribute`, go: `TraceAttribute`)**
 
 ```
@@ -100,9 +83,9 @@ In any case, the programmatic `TraceContext` interface is deceptively simple:
             |
      +------+------+
      |             |
- [Span B]      [Span C]  <-- (1) ATTRIBUTE "X" IS SET ON SPAN C'S
-     |             |             TRACECONTEXT, BUT AFTER SPAN E
- [Span D]      +---+-----+       ALREADY STARTED.
+ [Span B]      [Span C]  <-- (1) ATTRIBUTE "X" IS SET ON SPAN C,
+     |             |             BUT AFTER SPAN E ALREADY STARTED.
+ [Span D]      +---+-----+
                |         |
            [Span E]  [Span F]   <-- (2) ATTRIBUTE "X" IS AVAILABLE
                          |              FOR RETRIEVAL BY SPAN F (A
@@ -111,26 +94,37 @@ In any case, the programmatic `TraceContext` interface is deceptively simple:
             [Span G] [Span H] [Span I]
 ```
 
-### TraceContextSource, TraceContextEncoder, TraceContextDecoder
 
-A complete `Tracer` implementation must also satisfy the requirements of the `TraceContextSource`, `TraceContextEncoder`, and `TraceContextDecoder` interfaces.
+### Tracer
 
-Implementations create `TraceContext` instances via a `TraceContextSource` interface; it must have the following capabilities:
+The `Tracer` interface must have the following capabilities:
 
-- Create a new parent-less ("root") `TraceContext`. **(py: `new_root_trace_context`, go: `NewRootTraceContext`)**
-- Create a new child `TraceContext` given a parent `TraceContext`. **(py: `new_child_trace_context`, go: `NewChildTraceContext`)**
+- Start a `Span` that has no parent, commonly referred to as a *root* `Span` **(py: `start_trace`, go: `StartTrace`)**
+- Provide some form of access to a SpanPropagator (whether that's through embedding, inheritance, containment, or something else is per-platform)
 
-Additionally, a `TraceContextSource` must be able to encode and decode `TraceContext`s. These interfaces are exposed so that reusable libraries and middleware can transport trace information opaquely without binding to the implementation details of any specific tracing system.
+### SpanPropagator
 
-In its encoded form, a `TraceContext` is separated into a *pair* of values: one represents the "span identity" – for example, in Zipkin or Dapper, this would be the `trace_id` and `span_id`; and the other encoded value represents the trace attributes. This separation of encoded state enables optimizations in certain binary protocols. For instance, if a particular `TraceContext` has a fixed number of fixed-length "span identity" fields, then the span identity can be encoded into a fixed-length buffer (while of course the trace attributes cannot).
+A SpanPropagator is responsible (a) for encoding Span instances in a manner suitable for propagation, and (b) for taking that encoded data and using it
+to generate Span instances that are placed appropriately in the overarching Trace. Typically the propagation will take place across an RPC boundary, but message queues and other IPC mechanisms are also reasonable places to use a SpanPropagator.
 
-Note that there is no expectation that different tracing systems encode a `TraceContext` in compatible ways. Though OpenTracing is agnostic about the tracing implementation, for successful inter-process handoff it's essential that the processes on both sides use the same tracing implementation.
+The encoded form of a propagated span is divided into two components:
 
-Depending on the language, support for `TraceContext` coding may involve extending or embedding `TraceContextEncoder` and `TraceContextDecoder` interfaces with the following capabilities:
+1. The core identifying information for the Span (for example, in Dapper this would include a `trace_id`, a `span_id`, and a bitmask representing the sampling status for the given trace)
+1. Any trace attributes (per Span's ability to set trace attributes that propagate across process boundaries)
 
-Encoding and decoding may involve either **"binary"** or **"text"** formats. The "binary" format is an implementation-specific byte array (as opposed to a unicode/utf8 string); it is opaque at the OpenTracing level. The "text" format is a platform-idiomatic map from (unicode) `string` to `string`.
+The encoded data is separated in this way for a variety of reasons; the most important is to give OpenTracing users a portable way to opt out of Trace Attribute propagation entirely if they deem it a stability risk.
 
-- Encoding a `TraceContext` as a pair of binary values **(py: `trace_context_to_binary`, go: `TraceContextToBinary`)**
-- Encoding a `TraceContext` as a pair of text-encoded `string->string` maps, where the keys are suitable for HTTP headers (see the notes about "trace attribute" keys above) **(py: `trace_context_to_text`, go: `TraceContextToText`)**
-- Decoding a `TraceContext` given a pair of binary values **(py: `trace_context_from_binary`, go: `TraceContextFromBinary`)**
-- Decoding a `TraceContext` given a pair of textual `string->string` maps **(py: `trace_context_from_text`, go: `TraceContextFromText`)**
+The propagation and trace-joining methods come in two flavors: binary and text.
+
+- The *text* format is a platform-idiomatic map from (unicode) `string` to `string`; it is better-suited to pretty-printing and debugging
+- The *binary* format is an opaque byte array and is better-suited to compact, high-performance encoding, decoding, and transmission
+
+Note that there is no expectation that different tracing systems propagate `Spans` in compatible ways. Though OpenTracing is agnostic about the tracing implementation, for successful inter-process handoff it's essential that the processes on both sides of a propagation use the same tracing implementation.
+
+The `SpanPropagator` interface must have the following capabilities:
+- Propagating a Span instance by encoding it as either...
+  - a pair of binary values **(py: `propagate_span_as_binary`, go: `PropagateSpanAsBinary`)**, or
+  - a pair of text-encoded `string->string` maps, where the keys are suitable for use in HTTP headers (see the notes about "trace attribute" keys above) **(py: `propagate_span_as_text`, go: `PropagateSpanAsText`)**
+- Returning a new Span instance that joins to a Span previously propagated via either...
+  - a pair of binary values **(py: `join_trace_from_binary`, go: `JoinTraceFromBinary`)**, or
+  - a pair of `string->string` maps **(py: `join_trace_from_text`, go: `JoinTraceFromText`)**

--- a/spec.md
+++ b/spec.md
@@ -109,7 +109,7 @@ to generate Span instances that are placed appropriately in the overarching Trac
 
 The encoded form of a propagated span is divided into two components:
 
-1. The core identifying information for the Span (for example, in Dapper this would include a `trace_id`, a `span_id`, and a bitmask representing the sampling status for the given trace)
+1. The core identifying information for the Span, referred to as the "context snapshot" (for example, in Dapper this would include a `trace_id`, a `span_id`, and a bitmask representing the sampling status for the given trace)
 1. Any trace attributes (per Span's ability to set trace attributes that propagate across process boundaries)
 
 The encoded data is separated in this way for a variety of reasons; the most important is to give OpenTracing users a portable way to opt out of Trace Attribute propagation entirely if they deem it a stability risk.

--- a/use-cases.md
+++ b/use-cases.md
@@ -193,7 +193,7 @@ We have already used `log_event_with_payload` in the client Span use case. Event
     span.log_event('cache-miss') 
 ```
 
-The tracer automatically records a timestamp of the event, in contrast with tags that apply to the entire Span. In the future versions of the API it will be possible to associate an externally provided timestamp with the event, e.g. see [pull request #38](https://github.com/opentracing/opentracing-go/pull/38).
+The tracer automatically records a timestamp of the event, in contrast with tags that apply to the entire Span. It is also possible to associate an externally provided timestamp with the event, e.g. see [Log (Go)](https://github.com/opentracing/opentracing-go/blob/ca5c92cf/span.go#L53).
 
 ### Recording Spans With External Timestamps
 

--- a/use-cases.md
+++ b/use-cases.md
@@ -30,7 +30,7 @@ As a follow-up, suppose that as part of the business logic above we call another
                 span2.finish()
 ```
 
-We assume that for whatever reason develper does not want to start a new trace in this function if one hasn't been started by the caller already, so we account for `get_current_span` potentially returning `None`.
+We assume that, for whatever reason, the developer does not want to start a new trace in this function if one hasn't been started by the caller already, so we account for `get_current_span` potentially returning `None`.
 
 These two examples are intentionally naive. Usually developers will not want to pollute their business functions directly with tracing code, but use other means like a [function decorator in Python](https://github.com/uber-common/opentracing-python-instrumentation/blob/master/opentracing_instrumentation/local_span.py#L59):
 
@@ -44,41 +44,43 @@ These two examples are intentionally naive. Usually developers will not want to 
 
 When a server wants to trace execution of a request, it generally needs to go through these steps:
 
-  1. Attempt to decode Trace Context from the incoming request, in case the trace has already been started by the client.
-  1. Depending on the outcome, either start a new trace, or join the existing trace using decoded Trace Context. This operation starts a new Span.
-  1. Store the newly created span in some _request context_ that is propagated throughout the application, either by application code, or by the RPC framework.
-  1. Finally, close the span using `span.finish()` when the server has finished processing the request.
+  1. Attempt to join an existing trace given a Span that's been propagated alongside the incoming request (in case the trace has already been started by the client), or create a new trace if no such propagated Span could be found.
+  1. Store the newly created Span in some _request context_ that is propagated throughout the application, either by application code, or by the RPC framework.
+  1. Finally, close the Span using `span.finish()` when the server has finished processing the request.
 
-#### Decoding Trace Context from Incoming Request
+#### Joining to a Trace from an Incoming Request
 
-Let's assume that we have an HTTP server, and the Trace Context is propagated from the client via HTTP headers, accessible via `request.headers`:
+Let's assume that we have an HTTP server, and the Span is propagated from the client via HTTP headers, accessible via `request.headers`:
 
 ```python
-    context = tracer.trace_context_from_text(
-        trace_context_id=request.headers,
+    span = tracer.join_trace_from_text(
+        operation_name=operation,
+        context_snapshot=request.headers,
         trace_attributes=request.headers
     )
 ```
 
-Here we set both arguments of the decoding method to the `headers` map. The Tracer object knows which headers it needs to read in order to reconstruct Trace Context, which comprises a trace context ID and trace attributes.
+Here we set both arguments of the decoding method to the `headers` map. The Tracer object knows which headers it needs to read in order to reconstruct the context snapshot and any Trace Attributes.
 
-#### Starting a Server-Side Span
+The `operation` above refers to the name the server wants to give to the Span. For example, if the HTTP request was a POST against `/save_user/123`, the operation name can be set to `post:/save_user/`. OpenTracing API does not dictate how applications name the spans.
 
-The `context` object above can be `None`, if the Tracer did not find relevant headers in the incoming request, either because the client did not send them, or maybe the client is running with a different tracer implementation (e.g. Zipkin vs. AppDash). In this case the server needs to start a brand new trace, otherwise it should join the existing trace:
+#### Joining to or Starting a Trace from an Incoming Request
+
+The `span` object above can be `None` if the Tracer did not find relevant headers in the incoming request: presumably because the client did not send them. In this case the server needs to start a brand new trace.
 
 ```python
-    if context is None:
+    span = tracer.join_trace_from_text(
+        operation_name=operation,
+        context_snapshot=request.headers,
+        trace_attributes=request.headers
+    )
+    if span is None:
         span = tracer.start_trace(operation_name=operation)
-    else:
-        span = tracer.join_trace(operation_name=operation,
-                                 parent_trace_context=context)
     span.set_tag('http.method', request.method)
     span.set_tag('http.url', request.full_url)
 ```
 
-The `operation` above refers to the name the server wants to give to the Span. For example, if the HTTP request was a POST against `/save_user/123`, the operation name can be set to `post:/save_user/`. OpenTracing API does not dictate how application calls the spans.
-
-The `set_tag` calls are examples of recording additional information in the span about the request.
+The `set_tag` calls are examples of recording additional information in the Span about the request.
 
 #### In-Process Request Context Propagation
 
@@ -120,7 +122,7 @@ The downside of explicit context propagation is that it leaks what could be cons
 
 ### Tracing Client Calls
 
-When an application acts as an RPC client, it is expected to start a new tracing Span before making an outgoing request, and encode the new span's Trace Context into that request. The following example shows how it can be done for an HTTP request. 
+When an application acts as an RPC client, it is expected to start a new tracing Span before making an outgoing request, and propagate the new Span along with that request. The following example shows how it can be done for an HTTP request. 
 
 ```python
     def traced_request(request, operation, http_client):
@@ -134,9 +136,8 @@ When an application acts as an RPC client, it is expected to start a new tracing
             span = parent_span.start_child(operation_name=operation)
         span.set_tag('http.url', request.full_url)
 
-        # encode Trace Context into HTTP request headers
-        h_ctx, h_attr = tracer.trace_context_to_text(
-            trace_context=span.trace_context)
+        # Propagate the Span via HTTP request headers
+        h_ctx, h_attr = tracer.propagate_span_as_text(span)
 
         for key, value in h_ctx.iteritems():
             request.add_header(key, value)
@@ -162,29 +163,29 @@ When an application acts as an RPC client, it is expected to start a new tracing
             raise
 ```
 
-  * The `get_current_span()` function is not a part of the OpenTracing API. It is meant to represent some util method of retrieving the current span from the current request context propagated implicitly (as is often the case in Python).
-  * The encoding function `trace_context_to_text` returns two maps, one representing the encoding of the trace context identity, the other the trace context attributes. We copy both maps into the HTTP request headers.
-  * We assume the HTTP client is asynchronous, so it returns a Future, and we need to add an on-completion callback to be able to finish the current child span.
-  * If HTTP client returns a future with exception, we log the exception to the span with `log_event_with_payload` method.
-  * Because the HTTP client may throw an exception even before returning a Future, we use a try/catch block to finish the span in all circumstances, to ensure it is reported and avoid leaking resources.
+  * The `get_current_span()` function is not a part of the OpenTracing API. It is meant to represent some util method of retrieving the current Span from the current request context propagated implicitly (as is often the case in Python).
+  * The encoding function `propagate_span_as_text` returns two maps, one representing a snapshot of the Span's context, and the other the Trace Attributes. We copy both maps into the HTTP request headers.
+  * We assume the HTTP client is asynchronous, so it returns a Future, and we need to add an on-completion callback to be able to finish the current child Span.
+  * If the HTTP client returns a future with exception, we log the exception to the Span with `log_event_with_payload` method.
+  * Because the HTTP client may throw an exception even before returning a Future, we use a try/catch block to finish the Span in all circumstances, to ensure it is reported and avoid leaking resources.
 
 
 ### Using Distributed Context Propagation
 
-The client and server examples above took care of propagating Trace Context on the wire, which includes any Trace Attributes.  The client may use the Trace Attributes to pass additional data to the server and any other downstream server it might call.
+The client and server examples above propagated the Span/Trace over the wire, including any Trace Attributes. The client may use the Trace Attributes to pass additional data to the server and any other downstream server it might call.
 
 ```python
 
     # client side
-    span.trace_context.set_attribute('auth-token', '.....')
+    span.set_trace_attribute('auth-token', '.....')
 
     # server side (one or more levels down from the client)
-    token = span.trace_context.get_attribute('auth-token')
+    token = span.get_trace_attribute('auth-token')
 ```
 
 ### Logging Events
 
-We have already used `log_event_with_payload` in the client span use case. Events can be logged without a payload, and not just where the span is being created / finished. For example, the application may record a cache miss event in the middle of execution, as long as it can get access to the current span from request context:
+We have already used `log_event_with_payload` in the client Span use case. Events can be logged without a payload, and not just where the Span is being created / finished. For example, the application may record a cache miss event in the middle of execution, as long as it can get access to the current Span from the request context:
 
 ```python
 
@@ -192,22 +193,24 @@ We have already used `log_event_with_payload` in the client span use case. Event
     span.log_event('cache-miss') 
 ```
 
-The tracer automatically records a timestamp of the event, in contrast with tags that apply to the entire span. In the future versions of the API it will be possible to associate an externally provided timestamp with the event, e.g. see [pull request #38](https://github.com/opentracing/opentracing-go/pull/38).
+The tracer automatically records a timestamp of the event, in contrast with tags that apply to the entire Span. In the future versions of the API it will be possible to associate an externally provided timestamp with the event, e.g. see [pull request #38](https://github.com/opentracing/opentracing-go/pull/38).
 
 ### Recording Spans With External Timestamps
 
-There are scenarios when it is impractical to incorporate an OpenTracing compatible tracer into a service, for various reasons. For example, a user may have a log file of what's essentially span data coming from a black-box process (e.g. HAProxy). In order to get the data into an OpenTracing-compatible system, the API needs a way to record spans with extrenally captured timestamps. The current version of API does not have that capability: see [issue #20](https://github.com/opentracing/opentracing.github.io/issues/20).
+There are scenarios when it is impractical to incorporate an OpenTracing compatible tracer into a service, for various reasons. For example, a user may have a log file of what's essentially Span data coming from a black-box process (e.g. HAProxy). In order to get the data into an OpenTracing-compatible system, the API needs a way to record spans with extrenally captured timestamps. The current version of API does not have that capability: see [issue #20](https://github.com/opentracing/opentracing.github.io/issues/20).
 
 ### Setting "Debug" Mode
 
-Most tracing systems apply sampling to minimize the amount of trace data sent to the system.  Sometimes developers want to have a way to ensure that a particular trace is going to be recorded (sampled) by the tracing system, e.g. by including a special parameter in the HTTP request, like `debug=true`. The OpenTracing API does not have any insight into sampling techniques used by the implementation, so there is no explicit API to force it. However, the implementations are advised to recognized the `debug` Trace Attribute and take measures to record the span. In order to pass this attribute to tracing systems that rely on pre-trace sampling, the following approach can be used:
+`XXX: we don't have an API for this anymore.`
 
-```python
-
-    if request.get('debug'):
-        trace_context = tracer.new_root_trace_context()
-        trace_context.set_attribute('debug', True)
-        span = tracer.start_span_with_context(
-            operation_name=operation, 
-            trace_context=trace_context)
-```
+> Most tracing systems apply sampling to minimize the amount of trace data sent to the system.  Sometimes developers want to have a way to ensure that a particular trace is going to be recorded (sampled) by the tracing system, e.g. by including a special parameter in the HTTP request, like `debug=true`. The OpenTracing API does not have any insight into sampling techniques used by the implementation, so there is no explicit API to force it. However, the implementations are advised to recognized the `debug` Trace Attribute and take measures to record the Span. In order to pass this attribute to tracing systems that rely on pre-trace sampling, the following approach can be used:
+> 
+> ```python
+> 
+>     if request.get('debug'):
+>         trace_context = tracer.new_root_trace_context()
+>         trace_context.set_attribute('debug', True)
+>         span = tracer.start_span_with_context(
+>             operation_name=operation, 
+>             trace_context=trace_context)
+> ```


### PR DESCRIPTION
Per https://github.com/opentracing/opentracing-go/pull/40 and https://github.com/opentracing/opentracing.github.io/issues/24

I'll add a few comments inline.

This and https://github.com/opentracing/opentracing-go/pull/40 should have a shared fate.