### PR TITLE
use kramdown and update some misc things along the way

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -8,13 +8,12 @@ pages_list:
   "Contributors": '/contributors'
 
 # Dependencies
-markdown:         redcarpet
+markdown:         kramdown
 highlighter:      pygments
 
-redcarpet:
-  extensions: 
-    - autolink
-    - with_toc_data
+kramdown:
+  input: GFM
+  hard_wrap: false
 
 gems: 
   - jekyll-paginate

--- a/apis.md
+++ b/apis.md
@@ -2,11 +2,13 @@
 layout: page
 title: Per-Platform APIs
 ---
-OpenTracing APIs are available for the following platforms:
+OpenTracing APIs are in progress for the following platforms:
 
-* Golang - https://github.com/opentracing/opentracing-go
-* Python - https://github.com/opentracing/opentracing-python
+* Go - [https://github.com/opentracing/opentracing-go](https://github.com/opentracing/opentracing-go)
+* Java - [https://github.com/opentracing/opentracing-java](https://github.com/opentracing/opentracing-java)
+* Javascript - [https://github.com/opentracing/opentracing-javascript](https://github.com/opentracing/opentracing-javascript)
+* Python - [https://github.com/opentracing/opentracing-python](https://github.com/opentracing/opentracing-python)
 
 Please refer to the README files in the respective projects for examples of usage.
 
-OpenTracing APIs are pending for Java, browser Javascript, and Node.js Javascript. PHP, iOS, and Ruby are next on our list, though community contributions are welcome for other languages at any time.
+PHP, iOS, and Ruby are next on our list, though community contributions are welcome for other languages at any time.

--- a/contributors.md
+++ b/contributors.md
@@ -5,8 +5,11 @@ title: Authors and Contributors
 
 (in alphabetical order)
 
-* Adrian Cole (@adriancole)
-* Ben Sigelman (@bensigelman)
-* Stephen Gutekanst (@slimsag)
-* Yuri Shkuro (@yurishkuro)
-
+* @adriancole (Adrian Cole)
+* @bcronin (Ben Cronin)
+* @bensigelman (Ben Sigelman)
+* @michaelsembwever (mck)
+* @slimsag (Stephen Gutekanst)
+* @tschottdorf (Tobias Schottdorf)
+* @yurishkuro (Yuri Shkuro)
+* @dkuebric (Dan Kuebrich)


### PR DESCRIPTION
@yurishkuro per https://github.com/opentracing/opentracing.github.io/issues/49, the site mostly "works". The only meaningful regression is that code blocks don't do syntax highlighting. If you read to the bottom at https://github.com/jekyll/jekyll/issues/2709, one does not get the sense that there will be a fix anytime soon. And it seems like we'll have to migrate over, so why not now? (??) Or something.

The rest of the changes are just minor things I noticed while perusing the various pages looking for formatting glitches.