### PR TITLE
Subdivide the navbar and add info about v1.0RC

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -1,11 +1,15 @@
 # Content
-pages_list:       
+core_pages_list:       
   "Home": '/'
   "Semantic Specification": '/spec'
+  "Contributors": '/contributors'
+
+user_pages_list:       
   "Per-Platform APIs": '/apis'
   "Instrumentation Use Cases": '/use-cases'
+
+implementor_pages_list:       
   "Implementing OpenTracing": '/implementors'
-  "Contributors": '/contributors'
 
 # Dependencies
 markdown:         kramdown

--- a/_includes/sidebar.html
+++ b/_includes/sidebar.html
@@ -13,7 +13,18 @@
         `layout: page` in the front-matter. See readme for usage.
       {% endcomment %}
 
-      {% for page in site.pages_list %}
+      <div class="sidebar-group">The basics</div>
+      {% for page in site.core_pages_list %}
+        <a class="sidebar-nav-item{% if page[1] == node.url %} active{% endif %}" href="{{ page[1] }}">{{ page[0] }}</a>
+      {% endfor %}
+
+      <div class="sidebar-group">For users</div>
+      {% for page in site.user_pages_list %}
+        <a class="sidebar-nav-item{% if page[1] == node.url %} active{% endif %}" href="{{ page[1] }}">{{ page[0] }}</a>
+      {% endfor %}
+
+      <div class="sidebar-group">For implementors</div>
+      {% for page in site.implementor_pages_list %}
         <a class="sidebar-nav-item{% if page[1] == node.url %} active{% endif %}" href="{{ page[1] }}">{{ page[0] }}</a>
       {% endfor %}
 

--- a/_includes/sidebar.html
+++ b/_includes/sidebar.html
@@ -13,10 +13,10 @@
         `layout: page` in the front-matter. See readme for usage.
       {% endcomment %}
 
-      <div class="sidebar-group">The basics</div>
       {% for page in site.core_pages_list %}
         <a class="sidebar-nav-item{% if page[1] == node.url %} active{% endif %}" href="{{ page[1] }}">{{ page[0] }}</a>
       {% endfor %}
+      <a class="sidebar-nav-item" href="{{ site.github.repo }}">View on GitHub</a>
 
       <div class="sidebar-group">For users</div>
       {% for page in site.user_pages_list %}
@@ -28,7 +28,6 @@
         <a class="sidebar-nav-item{% if page[1] == node.url %} active{% endif %}" href="{{ page[1] }}">{{ page[0] }}</a>
       {% endfor %}
 
-      <a class="sidebar-nav-item" href="{{ site.github.repo }}">View on GitHub</a>
       <!-- 
       <a class="sidebar-nav-item" href="{{ site.github.repo }}/archive/v{{ site.version }}.zip">Download</a>
       <span class="sidebar-nav-item">Currently v{{ site.version }}</span> 

--- a/apis.md
+++ b/apis.md
@@ -20,6 +20,6 @@ PHP, iOS, and Ruby are next on our list, though community contributions are welc
 
 ### What does "1.0RC" mean?
 
-It means that the contributors have spent a while thinking through the APIs from above and below, prototyped bindings to several tracing systems and many calling contexts, and have settled on the scope and exposed by the various OpenTracing APIs.
+It means that the contributors have spent a while thinking through the APIs from above and below, prototyped bindings to several tracing systems and many calling contexts, and have converged on semantics for the various OpenTracing platform APIs.
 
 1.0RC means that we feel comfortable formally binding OpenTracing to production tracing systems and production application code: not just in dev branches, but in public PRs. Once those bindings have been vetted in real production environments (and any adjustments or additions made to OpenTracing as a result) we will announce OpenTracing 1.0.

--- a/apis.md
+++ b/apis.md
@@ -4,8 +4,8 @@ title: Per-Platform APIs
 ---
 OpenTracing APIs are **available** for the following platforms:
 
-* Go (1.0RC) - [https://github.com/opentracing/opentracing-go](https://github.com/opentracing/opentracing-go)
-* Python (1.0RC) - [https://github.com/opentracing/opentracing-python](https://github.com/opentracing/opentracing-python)
+* Go ([1.0RC](#v1rc)) - [https://github.com/opentracing/opentracing-go](https://github.com/opentracing/opentracing-go)
+* Python ([1.0RC](#v1rc)) - [https://github.com/opentracing/opentracing-python](https://github.com/opentracing/opentracing-python)
 
 OpenTracing APIs are **in progress** for the following platforms:
 
@@ -15,3 +15,11 @@ OpenTracing APIs are **in progress** for the following platforms:
 Please refer to the README files in the respective per-platform repositories for usage examples.
 
 PHP, iOS, and Ruby are next on our list, though community contributions are welcome for other languages at any time.
+
+<div id="v1rc"></div>
+
+### What does "1.0RC" mean?
+
+It means that the contributors have spent a while thinking through the APIs from above and below, prototyped bindings to several tracing systems and many calling contexts, and have settled on the scope and exposed by the various OpenTracing APIs.
+
+1.0RC means that we feel comfortable formally binding OpenTracing to production tracing systems and production application code: not just in dev branches, but in public PRs. Once those bindings have been vetted in real production environments (and any adjustments or additions made to OpenTracing as a result) we will announce OpenTracing 1.0.

--- a/public/css/syntax.css
+++ b/public/css/syntax.css
@@ -61,6 +61,7 @@
 .highlight .il { color: #f60 } /* Literal.Number.Integer.Long */
 
 figure.highlight { margin-left: 0px; margin-right: 0px; }
+.sidebar-group { margin-top: 20px; font-size: 125%; color: #2592c0; }
 
 .css .o,
 .css .o + .nt,


### PR DESCRIPTION
The revised sidebar:

![image](https://cloud.githubusercontent.com/assets/2251553/13153899/2434aef6-d62b-11e5-9c40-887edd3cd3d6.png)

