### PR TITLE
Minor update to implementors.md

### DIFF
--- a/implementors.md
+++ b/implementors.md
@@ -7,13 +7,10 @@ title: Implementing the OpenTracing APIs
 
 OpenTracing provides portable APIs for those adding instrumentation to their production systems.
 
-To make life easier for those implementing monitoring and tracing tools, OpenTracing handles the time-consuming process of designing and maintaining featureful tracings APIs across programming languages and respecting their various idioms. This allows tracing tool implementors to focus on delivering value and making the most of the instrumented data itself.
+To make life easier for those implementing monitoring and tracing tools, OpenTracing handles the time-consuming process of designing and maintaining featureful tracings APIs across programming languages while respecting their various idioms. This allows tracing tool implementors to focus on delivering value and making the most of the instrumented data itself.
 
 In a codebase instrumented with OpenTracing, adding or switching to an OpenTracing-compatible tool becomes an `O(1)` operation for the programmer: it's just a configuration change - there's no need to modify the code instrumentation itself. Since the instrumentation process is often the greatest obstacle to adoption, building an OpenTracing-compatible implementation is a great way to get a monitoring and tracing tool into the hands of more developers more quickly.
 
 ### How to Add an OpenTracing Implementation
 
-For more information about the current reference implementations for the various platforms, see the [OpenTracing GitHub page](https://github.com/opentracing).
-
-If you'd like to add support for a new language or tool, please reach out to the OpenTracing authors via [email](https://groups.google.com/forum/#!forum/distributed-tracing) or
-[gitter](https://gitter.im/opentracing/public).
+For information about current reference implementations on particular platforms, please reach out to the OpenTracing authors via [email](https://groups.google.com/forum/#!forum/distributed-tracing) or [gitter](https://gitter.im/opentracing/public).

--- a/implementors.md
+++ b/implementors.md
@@ -3,11 +3,17 @@ layout: page
 title: Implementing the OpenTracing APIs
 ---
 
+### Why OpenTracing?
+
 OpenTracing provides portable APIs for those adding instrumentation to their production systems.
 
 To make life easier for those implementing monitoring and tracing tools, OpenTracing handles the time-consuming process of designing and maintaining featureful tracings APIs across programming languages and respecting their various idioms. This allows tracing tool implementors to focus on delivering value and making the most of the instrumented data itself.
 
 In a codebase instrumented with OpenTracing, adding or switching to an OpenTracing-compatible tool becomes an `O(1)` operation for the programmer: it's just a configuration change - there's no need to modify the code instrumentation itself. Since the instrumentation process is often the greatest obstacle to adoption, building an OpenTracing-compatible implementation is a great way to get a monitoring and tracing tool into the hands of more developers more quickly.
 
-For more information about the current reference implementations for the various platforms, see the [OpenTracing Github page](https://github.com/opentracing). If you'd like to add support for a new language or tool, please reach out to the OpenTracing authors via [email](https://groups.google.com/forum/#!forum/distributed-tracing) or
+### How to Add an OpenTracing Implementation
+
+For more information about the current reference implementations for the various platforms, see the [OpenTracing GitHub page](https://github.com/opentracing).
+
+If you'd like to add support for a new language or tool, please reach out to the OpenTracing authors via [email](https://groups.google.com/forum/#!forum/distributed-tracing) or
 [gitter](https://gitter.im/opentracing/public).

--- a/implementors.md
+++ b/implementors.md
@@ -3,11 +3,11 @@ layout: page
 title: Implementing the OpenTracing APIs
 ---
 
-OpenTracing makes tracing portable for those adding instrumentation to their production systems.
+OpenTracing provides portable APIs for those adding instrumentation to their production systems.
 
-That said, it also makes life easier for those implementing monitoring and tracing tools: rather than spending time and effort learning the idioms of numerous platforms, designing featureful tracing APIs, and maintaining them, projects which implement OpenTracing can focus on delivering value and making the most of the instrumented data.
+To make life easier for those implementing monitoring and tracing tools, OpenTracing handles the time-consuming process of designing and maintaining featureful tracings APIs across programming languages and respecting their various idioms. This allows tracing tool implementors to focus on delivering value and making the most of the instrumented data itself.
 
-Furthermore, in a codebase instrumented with OpenTracing, adding (or switching to) an OpenTracing-compatible tool is an `O(1)` operation for the programmer: it's really just a configuration change. Since instrumentation is often the greatest obstacle to adoption, OpenTracing support is a great way to put a monitoring and/or tracing tool in the hands of more developers quickly.
+In a codebase instrumented with OpenTracing, adding or switching to an OpenTracing-compatible tool becomes an `O(1)` operation for the programmer: it's just a configuration change - there's no need to modify the code instrumentation itself. Since the instrumentation process is often the greatest obstacle to adoption, building an OpenTracing-compatible implementation is a great way to get a monitoring and tracing tool into the hands of more developers more quickly.
 
-For information about current reference implementations in particular platforms, please reach out to the OpenTracing authors via [email](https://groups.google.com/forum/#!forum/distributed-tracing) or
+For more information about the current reference implementations for the various platforms, see the [OpenTracing Github page](https://github.com/opentracing). If you'd like to add support for a new language or tool, please reach out to the OpenTracing authors via [email](https://groups.google.com/forum/#!forum/distributed-tracing) or
 [gitter](https://gitter.im/opentracing/public).


### PR DESCRIPTION
Very low-priority, minor pull request that updates the "Implementing the OpenTracing APIs" page text a bit.  The changes are:

**Split the text into two sections with headings.** The rationale here was I initially clicked on the link to find information *how* to implement the OpenTracing APIs -- but then found text on *why* it's a good idea to do so. Both pieces of information are good and necessary, but I think the headings help as people may come to the page primarily for one purpose or the other.

**Directly include a link to the GitHub repo.** I assume this is the de-facto place to get information on the reference implementations :)

...and also I added some word-smithing that I think makes the content a little more clear (hopefully the improvement here isn't entirely subjective!).


