### PR TITLE
Use the term Baggage in place of Trace Attributes

### DIFF
--- a/spec.md
+++ b/spec.md
@@ -51,7 +51,7 @@ Every Span may also have zero or more key/value **Tags**, which do not have time
 
 Spans may be **Injected** into and **Extracted** from objects that are used for inter-process communication (e.g., HTTP headers). In this way, Spans may propagate across process boundaries along with sufficient information to join up with the Trace in some remote process.
 
-**Baggage** is a set of key/value pairs stored in a Span and propagated _in-band_ to all future child Spans: in this way, the "Baggage" travels with the trace, hence the name. Given a full-stack OpenTracing integration, Baggage enables powerful functionality by transparently propagating arbitrary application data: for example, an end-user id may be added as Baggage in a mobile app, propagate (via the distributed tracing machinery) into the depths of a storage system, and recovered at the bottom of the stack to identify a particularly expensive SQL query.
+**Baggage** is a set of key/value pairs stored in a Span and propagated _in-band_ to all future children Spans: in this way, the "Baggage" travels with the trace, hence the name. Given a full-stack OpenTracing integration, Baggage enables powerful functionality by transparently propagating arbitrary application data: for example, an end-user id may be added as a Baggage item in a mobile app, propagate (via the distributed tracing machinery) into the depths of a storage system, and recovered at the bottom of the stack to identify a particularly expensive SQL query.
 
 Baggage comes with powerful _costs_ as well; since the Baggage is propagated in-band, if it is too large or the items too numerous it may decrease system throughput or increase RPC latencies.
 

--- a/use-cases.md
+++ b/use-cases.md
@@ -102,7 +102,7 @@ span = extractor.join_trace(
 )
 {% endhighlight %}
 
-Here we set both arguments of the decoding method to the `headers` map. The Tracer object knows which headers it needs to read in order to reconstruct the context snapshot and any Trace Attributes.
+Here we set both arguments of the decoding method to the `headers` map. The Tracer object knows which headers it needs to read in order to reconstruct the tracer state and any Baggage.
 
 The `operation` above refers to the name the server wants to give to the Span. For example, if the HTTP request was a POST against `/save_user/123`, the operation name can be set to `post:/save_user/`. OpenTracing API does not dictate how applications name the spans.
 
@@ -206,14 +206,14 @@ def traced_request(request, operation, http_client):
 
 ### Using Distributed Context Propagation
 
-The client and server examples above propagated the Span/Trace over the wire, including any Trace Attributes. The client may use the Trace Attributes to pass additional data to the server and any other downstream server it might call.
+The client and server examples above propagated the Span/Trace over the wire, including any Baggage. The client may use the Baggage to pass additional data to the server and any other downstream server it might call.
 
 {% highlight python %}
 # client side
-span.set_trace_attribute('auth-token', '.....')
+span.set_baggage_item('auth-token', '.....')
 
 # server side (one or more levels down from the client)
-token = span.get_trace_attribute('auth-token')
+token = span.get_baggage_item('auth-token')
 {% endhighlight %}
 
 ### Logging Events


### PR DESCRIPTION
C.f. https://github.com/opentracing/opentracing.github.io/issues/67:

"Baggage" is the *set* of Baggage items; so

  "Trace Attribute" == "Baggage Item"

and

  "Trace Attributes" == "Baggage"